### PR TITLE
Issue #39: Restrict project applications to internal users only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ before_install:
   - tar -xzf geckodriver-v0.20.1-linux64.tar.gz -C geckodriver
   - export PATH=$PATH:$PWD/geckodriver
 
+  # Secret key for travis testing
+  - export SECRET_KEY=MY_SUPER_SECRET_KEY
+
 install: 
   - pip install codecov
   - mkdir -vp /home/travis/build/tystakartografen/cogs3/logs

--- a/project/forms.py
+++ b/project/forms.py
@@ -102,6 +102,12 @@ class LocalizeModelChoiceField(forms.ModelChoiceField):
 
 class ProjectCreationForm(forms.ModelForm):
 
+    def set_user(self, user):
+        self.user = user
+
+    def clean(self):
+        self.instance.tech_lead = self.user
+
     class Meta:
         model = Project
         fields = [

--- a/project/tests/test_integration.py
+++ b/project/tests/test_integration.py
@@ -36,7 +36,7 @@ class ProjectIntegrationTests(SeleniumTestsBase):
         'id_document': test_file,
     }
 
-    def test_create_project(self):
+    def test_create_project_missing_fields(self):
         """
         Create a new project
         """
@@ -59,6 +59,9 @@ class ProjectIntegrationTests(SeleniumTestsBase):
             self.select_from_dropdown_by_id('id_funding_source', 1)
             self.submit_form(self.default_project_form_fields)
             assert "This field is required." in self.selenium.page_source
+
+    def test_create_project(self):
+        self.sign_in(self.user)
 
         self.get_url('')
         self.click_link_by_url(reverse('create-project'))

--- a/project/views.py
+++ b/project/views.py
@@ -28,10 +28,10 @@ class ProjectCreateView(SuccessMessageMixin, LoginRequiredMixin, generic.CreateV
     success_message = _("Successfully submitted a project application.")
     template_name = 'project/create.html'
 
-    def form_valid(self, form):
-        form.instance.tech_lead = self.request.user
-        return super().form_valid(form)
-
+    def get_form(self, *args, **kwargs):
+        form = super().get_form(*args, **kwargs)
+        form.set_user(self.request.user)
+        return form
 
 class ProjectListView(LoginRequiredMixin, generic.ListView):
     context_object_name = 'projects'

--- a/selenium_base.py
+++ b/selenium_base.py
@@ -94,7 +94,7 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
             first_name='User',
             last_name='User',
             is_staff=True,
-            is_shibboleth_login_required=False,
+            is_shibboleth_login_required=True,
         )
         self.create_test_user(self.user)
 
@@ -112,7 +112,7 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
             email="123456@swansea.ac.uk",
             first_name='Student',
             last_name='Student',
-            is_shibboleth_login_required=False,
+            is_shibboleth_login_required=True,
         )
         self.create_test_user(self.student)
 
@@ -123,7 +123,7 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
             last_name='Rse',
             is_staff=True,
             is_superuser=True,
-            is_shibboleth_login_required=False,
+            is_shibboleth_login_required=True,
         )
         self.create_test_user(self.rse)
 
@@ -134,7 +134,7 @@ class SeleniumTestsBase(StaticLiveServerTestCase):
             last_name='Admin',
             is_staff=True,
             is_superuser=True,
-            is_shibboleth_login_required=False,
+            is_shibboleth_login_required=True,
         )
         self.create_test_user(self.admin)
 

--- a/users/models.py
+++ b/users/models.py
@@ -72,6 +72,13 @@ class Profile(models.Model):
     def __str__(self):
         return self.user.email
 
+    @property
+    def institution(self):
+        """ return institution if shibboleth user, otherwise return None """
+        if hasattr(self, 'shibbolethprofile'):
+            return self.shibbolethprofile.institution
+        else:
+            return None
 
 class ShibbolethProfile(Profile):
     shibboleth_id = models.CharField(


### PR DESCRIPTION
Implementation of #39. Logic has been moved to form class rather than view, in anticipation of more institution-specific logic. Profile.institution property added which returns None is user has no institution.

Also, tests have been refactored slightly to tidy up and to add is_shibboleth_login_required=True to all internal users.