### PR TITLE
Remove project owner

### DIFF
--- a/project/apps.py
+++ b/project/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class ProjectConfig(AppConfig):
     name = 'project'
+
+    def ready(self):
+        import project.signals

--- a/project/models.py
+++ b/project/models.py
@@ -264,6 +264,20 @@ class Project(models.Model):
         except Exception:
             logger.exception('Failed assign project owner membership to the project\'s technical lead.')
 
+    def _remove_from_project_owner(self, old_techlead):
+        try:
+            # If the old tech lead no longer has any projects,
+            # remove them from the project_owner group
+            techlead_projects = Project.objects.filter(
+                tech_lead=old_techlead,
+                status=Project.APPROVED,
+            )
+            if techlead_projects.count() == 1:
+                group = Group.objects.get(name='project_owner')
+                old_techlead.groups.remove(group)
+        except Exception:
+            logger.exception('Failed assign project owner membership to the project\'s technical lead.')
+
     def _generate_project_code(self):
         prefix = 'scw'
         last_project = Project.objects.order_by('id').last()
@@ -279,8 +293,18 @@ class Project(models.Model):
     def save(self, *args, **kwargs):
         if self.code is '':
             self.code = self._generate_project_code()
+
         if self.status == Project.APPROVED:
             self._assign_project_owner_project_membership()
+
+        # If the project already exists check for changes
+        if(Project.objects.filter(pk=self.id).exists()):
+            current = Project.objects.get(pk=self.id)
+            if current.status == Project.APPROVED:
+                if self.tech_lead != current.tech_lead or \
+                   self.status != current.status:
+                    self._remove_from_project_owner(current.tech_lead)
+
         super(Project, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/project/signals.py
+++ b/project/signals.py
@@ -1,0 +1,21 @@
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
+from django.contrib.auth.models import Group
+
+from project.models import Project
+
+
+@receiver(pre_delete, sender=Project)
+def remove_tech_lead_from_project_owner(**kwargs):
+    # If the tech lead has no other projects, remove them
+    # from the project_owner group
+    project = kwargs["instance"]
+    tech_lead = project.tech_lead
+    status = project.status
+    techlead_projects = Project.objects.filter(
+        tech_lead=tech_lead,
+        status=Project.APPROVED,
+    )
+    if status == Project.APPROVED and techlead_projects.count() == 1:
+        group = Group.objects.get(name='project_owner')
+        tech_lead.groups.remove(group)

--- a/project/tests/test_integration.py
+++ b/project/tests/test_integration.py
@@ -122,6 +122,10 @@ class ProjectIntegrationTests(SeleniumTestsBase):
         project.code = 'code1'
         project.save()
 
+        # Check that the user was added to project_owners
+        if not self.user.groups.filter(name='project_owner').exists():
+            raise AssertionError()
+
         # Try the Project Applications and Project Memberships pages
         self.get_url('')
         self.click_link_by_url(reverse('project-application-list'))
@@ -181,6 +185,12 @@ class ProjectIntegrationTests(SeleniumTestsBase):
 
         if 'Authorised' not in self.selenium.page_source:
             raise AssertionError()
+
+        # Delete the project and check the user was deleted from project_owners
+        project.delete()
+        if self.user.groups.filter(name='project_owner').exists():
+            raise AssertionError()
+
 
     def test_create_project_external(self):
         """


### PR DESCRIPTION
Tech lead who does not have other projects is removed from project_owner when project is deleted or tech_lead is changed.

Fixes issue #57