### PR TITLE
Fix issues with migration tests and test fixtures

### DIFF
--- a/funding/tests/test_migrations.py
+++ b/funding/tests/test_migrations.py
@@ -12,7 +12,7 @@ class TestMigration(TestCase):
 
     def setUp(self):
         assert self.migrate_from and self.migrate_to, \
-            "migrate_to and migrate_from mist be defined"
+            "migrate_to and migrate_from must be defined"
         executor = MigrationExecutor(connection)
         apps = executor.loader.project_state(self.migrate_from).apps
 

--- a/project/fixtures/tests/memberships.json
+++ b/project/fixtures/tests/memberships.json
@@ -26,5 +26,19 @@
       "created_time": "2018-06-26T20:46:10.473Z",
       "modified_time": "2018-06-26T20:46:10.473Z"
     }
+  },
+  {
+    "model": "project.projectusermembership",
+    "pk": 3,
+    "fields": {
+      "project": 2,
+      "user": 7,
+      "status": 1,
+      "previous_status": 0,
+      "date_joined": "2018-06-26",
+      "date_left": "9999-12-31",
+      "created_time": "2018-06-26T20:46:10.473Z",
+      "modified_time": "2018-06-26T20:46:10.473Z"
+    }
   }
 ]

--- a/project/migrations/0042_create_allocation_request.py
+++ b/project/migrations/0042_create_allocation_request.py
@@ -39,18 +39,6 @@ def backwards(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('funding', '0001_initial'),
-        ('project', '0037_auto_20180717_1128'),
-    ]
-
-    operations = [
-        migrations.RunPython(forwards, backwards),
-    ]
-
-
-class Migration(migrations.Migration):
-
-    dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('project', '0041_auto_20180731_1239'),
     ]

--- a/project/tests/test_forms.py
+++ b/project/tests/test_forms.py
@@ -16,7 +16,7 @@ from users.models import CustomUser
 from users.tests.test_models import CustomUserTests
 
 
-class ProjectFormTests(TestCase):
+class ProjectFormTestCase(TestCase):
 
     fixtures = [
         'institution/fixtures/tests/institutions.json',
@@ -39,6 +39,24 @@ class ProjectFormTests(TestCase):
         # Create users for each institution
         self.institution_names, self.institution_users = CustomUserTests.create_institutional_users()
 
+
+class ProjectFormTests(ProjectFormTestCase):
+    def setUp(self):
+        super().setUp()
+        institution = self.institution_names[0]
+        user = self.institution_users[institution]
+        self.data = {
+            'title': 'Test Project',
+            'description': 'A test project',
+            'institution_reference': 'X',
+            'department': 'Testing Department',
+            'supervisor_name': 'supervisor',
+            'supervisor_position': 'Researcher',
+            'supervisor_email': 'supervisor@example.ac.uk',
+        }
+        self.form = ProjectCreationForm(user,self.data)
+
+
     def test_project_form_arcca_field(self):
         for i in self.institution_names:
             user = self.institution_users[i]
@@ -47,6 +65,13 @@ class ProjectFormTests(TestCase):
                 self.assertTrue('legacy_arcca_id' in form.fields)
             else:
                 self.assertFalse('legacy_arcca_id' in form.fields)
+
+    def test_project_form_valid(self):
+        self.assertTrue( self.form.is_valid() )
+
+    def test_project_form_supervisor_email(self):
+        self.form.data['supervisor_email'] = 'supervisor@gmail.com'
+        self.assertFalse( self.form.is_valid() )
 
 
 class AllocationRequestFormTests(TestCase):
@@ -78,7 +103,7 @@ class AllocationRequestFormTests(TestCase):
             form = SystemAllocationRequestCreationForm(user)
 
 
-class ProjectUserRequestMembershipFormTests(ProjectFormTests, TestCase):
+class ProjectUserRequestMembershipFormTests(ProjectFormTestCase):
 
     def test_request_membership_form_with_valid_data(self):
         pass
@@ -96,7 +121,7 @@ class ProjectUserRequestMembershipFormTests(ProjectFormTests, TestCase):
         pass
 
 
-class ProjectUserMembershipCreationFormTests(ProjectFormTests, TestCase):
+class ProjectUserMembershipCreationFormTests(ProjectFormTestCase):
 
     # Project are no longer approved, allocations are. Members can be added immediately
     # when a project is created.
@@ -272,7 +297,7 @@ class ProjectUserMembershipCreationFormTests(ProjectFormTests, TestCase):
         )
 
 
-class ProjectUserInviteFormTests(ProjectFormTests, TestCase):
+class ProjectUserInviteFormTests(ProjectFormTestCase):
 
     # Project are no longer approved, allocations are. Members can be added immediately
     # when a project is created.
@@ -391,7 +416,7 @@ class ProjectUserInviteFormTests(ProjectFormTests, TestCase):
         self.assertFalse(form.is_valid())
 
 
-class SystemAllocationRequestCreationFormTests(ProjectFormTests, TestCase):
+class SystemAllocationRequestCreationFormTests(ProjectFormTestCase):
 
     def test_form_with_unauthorized_project(self):
         """
@@ -418,7 +443,7 @@ class SystemAllocationRequestCreationFormTests(ProjectFormTests, TestCase):
         self.assertFalse(form.is_valid())
 
 
-class RSEAllocationRequestCreationFormTests(ProjectFormTests, TestCase):
+class RSEAllocationRequestCreationFormTests(ProjectFormTestCase):
     default_data = {
         'title': 'Project to implement a management system',
         'duration': 1,

--- a/project/tests/test_views.py
+++ b/project/tests/test_views.py
@@ -52,9 +52,6 @@ class ProjectViewTests(TestCase):
         # Applicant from an institution that does not verify users
         self.inst2_applicant = CustomUser.objects.get(email='test.user@example2.ac.uk')
 
-        # Applicant from an institution that does not verify users
-        self.inst2_applicant = CustomUser.objects.get(email='test.user@example2.ac.uk')
-
         self.project = Project.objects.get(code='scw0000')
         self.project_owner = self.project.tech_lead
 
@@ -159,8 +156,8 @@ class ProjectCreateViewTests(ProjectViewTests, TestCase):
 
     def test_view_without_user_approval_with_project_add_permission(self):
         """
-        Ensure the project create view is accessible to a user who is not required to be authorised,
-        who does have the required permissions.
+        Ensure the project create view is accessible to a user who is not required
+        to be authorised, who does have the required permissions.
         """
         headers = {
             'Shib-Identity-Provider': self.inst2_applicant.profile.institution.identity_provider,
@@ -505,44 +502,6 @@ class ProjectUserRequestMembershipListViewTests(ProjectViewTests, TestCase):
             reverse('project-user-membership-request-list'),
             '/en-gb/accounts/login/?next=/en-gb/projects/memberships/user-requests/',
         )
-
-
-class ProjectUserRequestMembershipUpdateViewTests(ProjectViewTests, TestCase):
-
-    def test_view_as_authorised_application_user_without_project_change_membership_permission(self):
-        """
-        Ensure the project user request membership update view is not accessible to an authorised
-        application user, who does not have the required permissions.
-        """
-        pass
-
-    def test_view_as_authorised_application_user_with_project_change_membership_permission(self):
-        """
-        Ensure the project user request membership update view is accessible to an authorised
-        application user, who does not have the required permissions.
-        """
-        pass
-
-    def test_view_as_without_user_authorisation_with_project_change_membership_permission(self):
-        """
-        Ensure the project user request membership update view is accessible to a user who is
-        not required to be authorised, who does not have the required permissions.
-        """
-        pass
-
-    def test_view_as_authorised_application_user_with_invalid_request_params(self):
-        """
-        Ensure it is not possible for a user, who is not the project's technical lead, to update
-        a project membership user request.
-        """
-        pass
-
-    def test_view_as_unauthorised_application_user(self):
-        """
-        Ensure the project user request membership update view is not accessible to an unauthorised
-        application user.
-        """
-        pass
 
 
 class ProjectUserMembershipListViewTests(ProjectViewTests, TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ codecov==2.0.15
 coverage==4.5.1
 cryptography==2.3
 dj-database-url==0.4.2
-Django==2.1.7
+Django==2.1.4
 django-classy-tags==0.8.0
 django-cookie-law==1.0.13
 django-extensions==2.0.5


### PR DESCRIPTION
Change Django version for a quick fix to the migration tests.

Fix two minor coding issues.

Fix issue with project view tests. Since we only allow project members to view projects, a membership needed to be added for the techlead of project 2 in test fixtures