### PR TITLE
institution link should contain ?target= for redirect

### DIFF
--- a/templates/registration/educational_login.html
+++ b/templates/registration/educational_login.html
@@ -14,7 +14,7 @@
     <div class="list-group">
         {% for institution in institutions %}
             {% if institution.identity_provider %}
-                <a id="{{institution.id_str}}-login-link" href="{{shibboleth_idp_login}}?entityID={{institution.identity_provider}}" class="text-center border-0 mt-3 list-group-item list-group-item-action flex-column align-items-start box-shadow">
+                <a id="{{institution.id_str}}-login-link" href="{{shibboleth_idp_login}}?entityID={{institution.identity_provider}}&target=https://scw.bangor.ac.uk{{next}}" class="text-center border-0 mt-3 list-group-item list-group-item-action flex-column align-items-start box-shadow">
                     <img class="img-fluid" src="{{institution.logo_path}}" alt="{% trans "{{institution}}" %}">
                 </a>
             {% endif %}


### PR DESCRIPTION
I've hard-coded scw.bangor.ac.uk here, in order to apply a minimal change
to the live environment (as this change cannot be tested).

A better approach would be to read this from settings.